### PR TITLE
### Prevenção de Títulos Duplicados em Jogos

### DIFF
--- a/FCG.Application/Services/GameService.cs
+++ b/FCG.Application/Services/GameService.cs
@@ -33,9 +33,8 @@ namespace FCG.Application.Services
         }
 
         public async Task<GameDTO> GetGameByIdAsync(int id)
-        {
-            var game = await _gameRepository.GetByIdAsync(id);
-
+        { 
+            var game = await _gameRepository.GetBy(game => game.Id.Equals(id));
             if (game == null)
                 throw new NotFoundException("Jogo não encontrado.");
 
@@ -51,6 +50,10 @@ namespace FCG.Application.Services
 
         public async Task<GameDTO> CreateGameAsync(CreateGameModel model)
         {
+            var existingGame = await _gameRepository.GetBy(g => g.Title.ToUpper() == model.Title.ToUpper());
+            if (existingGame is not null)
+                throw new BusinessErrorDetailsException($"Jogo com o título '{model.Title}' já existe.");
+
             var game = new Game
             (
                 model.Title,
@@ -73,7 +76,11 @@ namespace FCG.Application.Services
 
         public async Task UpdateGameAsync(int id, UpdateGameModel model)
         {
-            var game = await _gameRepository.GetByIdAsync(id);
+            var game = await _gameRepository.GetBy(g => g.Id.Equals(id));
+            var ExistingGame = await _gameRepository.GetBy(g => g.Title.ToUpper() == model.Title.ToUpper() && g.Id != id);
+
+            if (ExistingGame is not null)
+                throw new BusinessErrorDetailsException($"Jogo com o título '{model.Title}' já existe.");
 
             if (game == null)
                 throw new NotFoundException($"Jogo {id} não encontrado.");
@@ -101,7 +108,7 @@ namespace FCG.Application.Services
 
         public async Task DeleteGameAsync(int id)
         {
-            var game = await _gameRepository.GetByIdAsync(id);
+            var game = await _gameRepository.GetBy(g => g.Id.Equals(id));
 
             if (game == null)
                 throw new NotFoundException($"Jogo {id} não encontrado.");

--- a/FCG.Domain/Interfaces/IGameRepository.cs
+++ b/FCG.Domain/Interfaces/IGameRepository.cs
@@ -1,12 +1,12 @@
 ﻿using FCG.Domain.Entities;
+using System.Linq.Expressions;
 
 namespace FCG.Domain.Interfaces;
 
 public interface IGameRepository
 {
-    Task<Game?> GetByIdAsync(int id);
+    Task<Game?> GetBy(Expression<Func<Game, bool>> condition);
     Task<IEnumerable<Game>> GetAllAsync();
-    Task<bool> TitleExistsAsync(string title);
     Task AddAsync(Game game);
     Task UpdateAsync(Game game);
     Task DeleteAsync(int id);

--- a/FCG.Domain/Interfaces/IGameRepository.cs
+++ b/FCG.Domain/Interfaces/IGameRepository.cs
@@ -4,8 +4,9 @@ namespace FCG.Domain.Interfaces;
 
 public interface IGameRepository
 {
-    Task<Game> GetByIdAsync(int id);
+    Task<Game?> GetByIdAsync(int id);
     Task<IEnumerable<Game>> GetAllAsync();
+    Task<bool> TitleExistsAsync(string title);
     Task AddAsync(Game game);
     Task UpdateAsync(Game game);
     Task DeleteAsync(int id);

--- a/FCG.Infra.Data/FCG.Infra.Data.csproj
+++ b/FCG.Infra.Data/FCG.Infra.Data.csproj
@@ -20,6 +20,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.5" />

--- a/FCG.Infra.Data/Mappings/GameMapping.cs
+++ b/FCG.Infra.Data/Mappings/GameMapping.cs
@@ -16,6 +16,9 @@ namespace FCG.Infra.Data.Mappings
             builder.Property(j => j.Id)
                    .ValueGeneratedOnAdd();
 
+            builder.HasIndex(j => j.Title)
+                    .IsUnique();
+
             builder.Property(j => j.Title)
                    .IsRequired()
                    .HasMaxLength(100);

--- a/FCG.Infra.Data/Migrations/20250623131617_UniqueTitle.Designer.cs
+++ b/FCG.Infra.Data/Migrations/20250623131617_UniqueTitle.Designer.cs
@@ -4,6 +4,7 @@ using FCG.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FCG.Infra.Data.Migrations
 {
     [DbContext(typeof(FCGDbContext))]
-    partial class FCGDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250623131617_UniqueTitle")]
+    partial class UniqueTitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FCG.Infra.Data/Migrations/20250623131617_UniqueTitle.cs
+++ b/FCG.Infra.Data/Migrations/20250623131617_UniqueTitle.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FCG.Infra.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UniqueTitle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_games_Title",
+                table: "games",
+                column: "Title",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_games_Title",
+                table: "games");
+        }
+    }
+}

--- a/FCG.Infra.Data/Repository/GameRepository.cs
+++ b/FCG.Infra.Data/Repository/GameRepository.cs
@@ -36,6 +36,13 @@ public class GameRepository(FCGDbContext context) : IGameRepository
             await _context.Games.FirstOrDefaultAsync(u => u.Id == id);
     }
 
+    public async Task<bool> TitleExistsAsync(string title)
+    {
+        return await _context.Games
+            .AsNoTracking()
+            .AnyAsync(g => g.Title != null && g.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+    }
+
     public async Task UpdateAsync(Game game)
     {
         _context.Games.Update(game);

--- a/FCG.Infra.Data/Repository/GameRepository.cs
+++ b/FCG.Infra.Data/Repository/GameRepository.cs
@@ -3,6 +3,7 @@ using FCG.Domain.Exceptions;
 using FCG.Domain.Interfaces;
 using FCG.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace FCG.Infra.Data.Repository;
 
@@ -18,7 +19,7 @@ public class GameRepository(FCGDbContext context) : IGameRepository
 
     public async Task DeleteAsync(int id)
     {
-        var game = await GetByIdAsync(id);
+        var game = await GetBy(g => g.Id.Equals(id));
         _context.Games.Remove(game);
         await _context.SaveChangesAsync();
     }
@@ -30,19 +31,12 @@ public class GameRepository(FCGDbContext context) : IGameRepository
             .ToListAsync();
     }
 
-    public async Task<Game?> GetByIdAsync(int id)
-    {
-        return
-            await _context.Games.FirstOrDefaultAsync(u => u.Id == id);
-    }
-
-    public async Task<bool> TitleExistsAsync(string title)
+    public async Task<Game?> GetBy(Expression<Func<Game, bool>> condition)
     {
         return await _context.Games
             .AsNoTracking()
-            .AnyAsync(g => g.Title != null && g.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefaultAsync(condition);
     }
-
     public async Task UpdateAsync(Game game)
     {
         _context.Games.Update(game);

--- a/FCG.Infra.Data/Repository/GameRepository.cs
+++ b/FCG.Infra.Data/Repository/GameRepository.cs
@@ -20,8 +20,12 @@ public class GameRepository(FCGDbContext context) : IGameRepository
     public async Task DeleteAsync(int id)
     {
         var game = await GetBy(g => g.Id.Equals(id));
-        _context.Games.Remove(game);
-        await _context.SaveChangesAsync();
+        if (game != null)
+        {
+            _context.Games.Attach(game);
+            _context.Games.Remove(game);
+            await _context.SaveChangesAsync();
+        }
     }
 
     public async Task<IEnumerable<Game>> GetAllAsync()

--- a/FCG.Tests.Infra/Repository/GameRepositoryTests.cs
+++ b/FCG.Tests.Infra/Repository/GameRepositoryTests.cs
@@ -2,7 +2,6 @@
 using FCG.Domain.Entities;
 using FCG.Infra.Data.Context;
 using FCG.Infra.Data.Repository;
-using FCG.Domain.ValueObjects;
 
 namespace FCG.Infra.Tests.Repositories;
 
@@ -16,6 +15,7 @@ public class GameRepositoryTests
         var options = new DbContextOptionsBuilder<FCGDbContext>()
             .UseInMemoryDatabase(databaseName: "TestDatabase")
             .Options;
+
         _context = new FCGDbContext(options);
         _repository = new GameRepository(_context);
     }
@@ -24,14 +24,85 @@ public class GameRepositoryTests
     public async Task AddAsync_ValidGame_ShouldAddGameToDatabase()
     {
         // Arrange
-        var game = new Game("Game Title", 199.99M, "descricao", "terror");
+        var game = new Game("Tetris", 9.99M, "Puzzle Clássico", "Puzzle");
 
         // Act
         await _repository.AddAsync(game);
+        var savedGame = await _repository.GetBy(g => g.Title == game.Title);
 
         // Assert
-        var savedGame = await _context.Games.FirstOrDefaultAsync();
         Assert.NotNull(savedGame);
-        Assert.Equal("Game Title", savedGame.Title);
+        Assert.Equal("Tetris", savedGame.Title);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DeleteExistingGame_ShouldRemoveGameFromDatabase()
+    {
+        // Arrange
+        var game = new Game("The Witcher 3", 49.99M, "RPG de Ação", "RPG");
+        await _repository.AddAsync(game);
+        var gameToDelete = _repository.GetBy(g => g.Title == "The Witcher 3");
+        _context.ChangeTracker.Clear();
+
+        // Act
+        await _repository.DeleteAsync(gameToDelete.Id);
+
+        // Assert
+        Assert.Null(await _repository.GetBy(g => g.Id.Equals(gameToDelete.Id)));
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ShouldReturnAllGames()
+    {
+        // Arrange
+        var games = new List<Game>
+        {
+            new Game("Sonic 2", 49.99M, "Plataforma 2d", "Paltaforma"),
+            new Game("Deus Ex", 59.99M, "RPG de Ação", "RPG"),
+            new Game("Resident Evil 3", 39.99M, "Survival Horror", "Horror")
+        };
+        _context.Games.AddRange(games);
+        _context.SaveChanges();
+        // Act
+        var result = await _repository.GetAllAsync();
+
+        // Assert
+        Assert.Equal(_context.Games.Count(), result.Count());
+        Assert.Contains(result, g => g.Title == "Sonic 2");
+        Assert.Contains(result, g => g.Title == "Deus Ex");
+        Assert.Contains(result, g => g.Title == "Resident Evil 3");
+    }
+
+    [Fact]
+    public async Task GetBy_ByTitle_ShouldReturnGame()
+    {
+        // Arrange
+        var game = new Game("Cyberpunk 2077", 99.99M, "RPG de Ação", "RPG");
+        await _repository.AddAsync(game);
+
+        // Act
+        var result = await _repository.GetBy(g => g.Title == "Cyberpunk 2077");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Cyberpunk 2077", result.Title);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ModifyPrice_ShouldModify()
+    {
+        // Arrange
+        var game = new Game("Resident Evil 4", 39.99M, "Survival Horror", "Horror");
+        await _repository.AddAsync(game);
+        var newPrice = 59.99M;
+
+        // Act
+        game.Price = newPrice;
+        await _repository.UpdateAsync(game);
+
+        // Assert
+        var updatedGame = await _repository.GetBy(g => g.Title == "Resident Evil 4");
+        Assert.NotNull(updatedGame);
+        Assert.Equal(newPrice, updatedGame.Price);
     }
 }


### PR DESCRIPTION
#### Classificação do Pull Request
Melhoria da funcionalidade de gerenciamento de jogos para prevenir títulos duplicados.

#### Resumo do Pull Request
Este pull request introduz verificações de validação para prevenir a criação e atualização de jogos com títulos duplicados, juntamente com atualizações no esquema do banco de dados para garantir a unicidade do título. Principais mudanças:
- `GameService.cs`: Refatorado `CreateGameAsync` e `UpdateGameAsync` com uso do método genérico `GetBy` e adicionado checagem para títulos únicos.
- `IGameRepository.cs`: Substituído `GetByIdAsync` pelo método genérico `GetBy` para consultas mais versáteis.
- `GameMapping.cs`: Adicionado index único na propriedade `Title` da entidade `Game`.
- Adicionada a migration `20250623131617_UniqueTitle.cs` para modificar o banco de dados.
- `GameRepository.cs`: Implementado o novo método `GetBy` e ajustado o método `DeleteAsync`.
- `GameRepositoryTests.cs`: Atualizado os testes para refletir as mudanças no repositório e garantir a regra de título único.
