### PR TITLE
Ativar monitoramento com New Relic

### DIFF
--- a/FCG.API/Dockerfile
+++ b/FCG.API/Dockerfile
@@ -5,6 +5,11 @@ WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
 
+# Ativa New Relic via variáveis de ambiente
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER="{36032161-FFC0-4B61-B559-F6C5D41BAE5A}"
+ENV NEW_RELIC_APP_NAME="fcg-api"
+
 # Build
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release

--- a/FCG.API/FCG.API.csproj
+++ b/FCG.API/FCG.API.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageReference Include="NewRelic.Agent" Version="10.43.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
   </ItemGroup>


### PR DESCRIPTION
Adicionadas variáveis de ambiente no Dockerfile para ativar o New Relic, permitindo o monitoramento de desempenho da aplicação. Incluída a referência ao pacote `NewRelic.Agent` no `FCG.API.csproj` para integração com o New Relic.